### PR TITLE
(hopefully) no cloudlink usernames

### DIFF
--- a/main.py
+++ b/main.py
@@ -141,7 +141,11 @@ async def direct(client, message):
                         db.insert_data(
                             "posts",
                             (
-                                str(authenticated_client_usernames[authenticated_clients.index(client.id)]),
+                                str(
+                                    authenticated_client_usernames[
+                                        authenticated_clients.index(client.id)
+                                    ]
+                                ),
                                 float(time.time()),
                                 uid,
                                 str(message["val"]["val"]["p"]),
@@ -159,7 +163,9 @@ async def direct(client, message):
                                 "val": {
                                     "cmd": "rpost",
                                     "val": {
-                                        "author": authenticated_client_usernames[authenticated_clients.index(client.id)],
+                                        "author": authenticated_client_usernames[
+                                            authenticated_clients.index(client.id)
+                                        ],
                                         "post_content": str(message["val"]["val"]["p"]),
                                         "uid": uid,
                                         "attachment": attachment,
@@ -169,13 +175,17 @@ async def direct(client, message):
                         )
                         audit.log_action(
                             "post",
-                            authenticated_client_usernames[authenticated_clients.index(client.id)],
+                            authenticated_client_usernames[
+                                authenticated_clients.index(client.id)
+                            ],
                             f"User posted {str(message["val"]["val"]["p"])}",
                         )
                         if SETTINGS["bridge_enabled"]:
                             url = "https://splashpost.vercel.app/home/"
                             payload = (
-                                authenticated_client_usernames[authenticated_clients.index(client.id)]
+                                authenticated_client_usernames[
+                                    authenticated_clients.index(client.id)
+                                ]
                                 + ": "
                                 + str(message["val"]["val"]["p"]).strip()
                                 + (
@@ -197,9 +207,17 @@ async def direct(client, message):
                         )
                         print(selection)
                         print(selection[0][0])
-                        print(authenticated_client_usernames[authenticated_clients.index(client.id)])
+                        print(
+                            authenticated_client_usernames[
+                                authenticated_clients.index(client.id)
+                            ]
+                        )
                         if selection:
-                            if str(selection[0][0]) == str(authenticated_client_usernames[authenticated_clients.index(client.id)]):
+                            if str(selection[0][0]) == str(
+                                authenticated_client_usernames[
+                                    authenticated_clients.index(client.id)
+                                ]
+                            ):
                                 db.update_data(
                                     "posts",
                                     {"isDeleted": True},
@@ -219,7 +237,9 @@ async def direct(client, message):
                                 )
                                 audit.log_action(
                                     "delete",
-                                    authenticated_client_usernames[authenticated_clients.index(client.id)],
+                                    authenticated_client_usernames[
+                                        authenticated_clients.index(client.id)
+                                    ],
                                     f"User deleted post with UID {str(message["val"]["val"]["uid"])}",
                                 )
                             else:
@@ -231,14 +251,20 @@ async def direct(client, message):
                                             "cmd": "status",
                                             "val": {
                                                 "message": "Not authorized",
-                                                "username": authenticated_client_usernames[authenticated_clients.index(client.id)],
+                                                "username": authenticated_client_usernames[
+                                                    authenticated_clients.index(
+                                                        client.id
+                                                    )
+                                                ],
                                             },
                                         },
                                     },
                                 )
                                 audit.log_action(
                                     "delete_fail",
-                                    authenticated_client_usernames[authenticated_clients.index(client.id)],
+                                    authenticated_client_usernames[
+                                        authenticated_clients.index(client.id)
+                                    ],
                                     f"User tried to delete a post with UID {str(message["val"]["val"]["uid"])} that doesn't belong to their account",
                                 )
                         else:
@@ -250,14 +276,18 @@ async def direct(client, message):
                                         "cmd": "status",
                                         "val": {
                                             "message": "Post not found",
-                                            "username": authenticated_client_usernames[authenticated_clients.index(client.id)],
+                                            "username": authenticated_client_usernames[
+                                                authenticated_clients.index(client.id)
+                                            ],
                                         },
                                     },
                                 },
                             )
                             audit.log_action(
                                 "delete_fail",
-                                authenticated_client_usernames[authenticated_clients.index(client.id)],
+                                authenticated_client_usernames[
+                                    authenticated_clients.index(client.id)
+                                ],
                                 f"User tried to delete a post with UID {str(message["val"]["val"]["uid"])} that didn't exist",
                             )
                 case "edit":
@@ -269,7 +299,11 @@ async def direct(client, message):
                             conditions={"uid": str(message["val"]["val"]["uid"])},
                         )
                         if selection:
-                            if str(selection[0][0]) != str(authenticated_client_usernames[authenticated_clients.index(client.id)]):
+                            if str(selection[0][0]) != str(
+                                authenticated_client_usernames[
+                                    authenticated_clients.index(client.id)
+                                ]
+                            ):
                                 server.send_packet_unicast(
                                     client,
                                     {
@@ -278,14 +312,20 @@ async def direct(client, message):
                                             "cmd": "status",
                                             "val": {
                                                 "message": "Not authorized",
-                                                "username": authenticated_client_usernames[authenticated_clients.index(client.id)],
+                                                "username": authenticated_client_usernames[
+                                                    authenticated_clients.index(
+                                                        client.id
+                                                    )
+                                                ],
                                             },
                                         },
                                     },
                                 )
                                 audit.log_action(
                                     "edit_fail",
-                                    authenticated_client_usernames[authenticated_clients.index(client.id)],
+                                    authenticated_client_usernames[
+                                        authenticated_clients.index(client.id)
+                                    ],
                                     f"User tried to edit a post with UID {str(message["val"]["val"]["uid"])} that doesn't belong to their account",
                                 )
                             else:
@@ -316,7 +356,9 @@ async def direct(client, message):
                                 )
                                 audit.log_action(
                                     "edit",
-                                    authenticated_client_usernames[authenticated_clients.index(client.id)],
+                                    authenticated_client_usernames[
+                                        authenticated_clients.index(client.id)
+                                    ],
                                     f"User edited a post with UID {str(message["val"]["val"]["uid"])}",
                                 )
                         else:
@@ -328,7 +370,9 @@ async def direct(client, message):
                                         "cmd": "status",
                                         "val": {
                                             "message": "Post not found",
-                                            "username": authenticated_client_usernames[authenticated_clients.index(client.id)],
+                                            "username": authenticated_client_usernames[
+                                                authenticated_clients.index(client.id)
+                                            ],
                                         },
                                     },
                                 },


### PR DESCRIPTION
currently, because Cloudlink™, you can just change your username after authenticating. this _should_ fix it, unless my code is crap (like usual).

this PR just adds all usernames to a list, and these usernames should have the same index as the client ID, altho i havent tested this yet.
